### PR TITLE
v0.3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - ".github/FUNDING.yml"
       - ".pre-commit-hooks.yaml"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths-ignore:
       - "**.md"
@@ -30,6 +31,7 @@ jobs:
   fmt:
     name: Format Check
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
@@ -42,6 +44,7 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -83,6 +86,7 @@ jobs:
   check:
     name: Check
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -122,6 +126,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -160,6 +165,7 @@ jobs:
   test-debug:
     name: Test (Debug)
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -199,6 +205,7 @@ jobs:
   test-release:
     name: Test (Release)
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -238,6 +245,7 @@ jobs:
   python-bindings:
     name: Python Bindings
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -283,6 +291,7 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.61.1",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +355,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -786,6 +805,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1163,7 @@ dependencies = [
  "dirs",
  "fs-err",
  "futures",
+ "indicatif",
  "owo-colors",
  "pep440_rs",
  "pyo3",
@@ -1961,6 +1994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2270,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "pysentry"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ clap = { version = "4.5.48", features = ["derive"] }
 dirs = "6.0.0"
 fs-err = "3.1.2"
 futures = "0.3.31"
+indicatif = "0.18.0"
 owo-colors = "4.2.2"
 pep440_rs = "0.7.3"
 pyo3 = { version = "0.26.0", features = ["extension-module"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pysentry"
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 rust-version = "1.79"
 description = "Security vulnerability auditing for Python packages"

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ pysentry /path/to/project
 pysentry --resolver uv /path/to/project
 pysentry --resolver pip-tools /path/to/project
 
-# Include all dependencies (main + dev + optional)
-pysentry --all-extras
+# Exclude extra dependencies (only check main dependencies)
+pysentry --exclude-extra
 
 # Filter by severity (only show high and critical)
 pysentry --severity high
@@ -187,8 +187,8 @@ pysentry --format json --output audit-results.json
 ### Advanced Usage
 
 ```bash
-# Using uvx for comprehensive audit
-uvx pysentry-rs --all-extras --format sarif --output security-report.sarif
+# Using uvx for comprehensive audit (extras included by default)
+uvx pysentry-rs --format sarif --output security-report.sarif
 
 # Check multiple vulnerability sources concurrently
 uvx pysentry-rs --sources pypa,osv,pypi /path/to/project
@@ -200,8 +200,8 @@ uvx pysentry-rs --format markdown --output security-report.md
 # Control CI exit codes - only fail on critical vulnerabilities
 uvx pysentry-rs --fail-on critical
 
-# Or with installed binary
-pysentry --all-extras --format sarif --output security-report.sarif
+# Or with installed binary (extras included by default)
+pysentry --format sarif --output security-report.sarif
 pysentry --sources pypa,osv --direct-only
 pysentry --format markdown --output security-report.md
 
@@ -253,8 +253,8 @@ pysentry --sources pypa,pypi,osv --format json --output prod-security.json
 # Generate markdown report for GitHub issues/PRs
 pysentry --format markdown --output SECURITY-REPORT.md
 
-# Comprehensive audit with all sources and full reporting
-pysentry --sources pypa,pypi,osv --all-extras --format json --fail-on low
+# Comprehensive audit with all sources and full reporting (extras included by default)
+pysentry --sources pypa,pypi,osv --format json --fail-on low
 
 # CI environment with fresh resolution cache
 pysentry --clear-resolution-cache --sources pypa,osv --format sarif
@@ -350,7 +350,7 @@ ids = ["CVE-2023-12345", "GHSA-xxxx-yyyy-zzzz"]
 | `--severity`               | Minimum severity: `low`, `medium`, `high`, `critical`     | `low`             |
 | `--fail-on`                | Fail (exit non-zero) on vulnerabilities ≥ severity        | `medium`          |
 | `--sources`                | Vulnerability sources: `pypa`, `pypi`, `osv` (multiple)   | `pypa`            |
-| `--all-extras`             | Include all dependencies (main + dev + optional)          | `false`           |
+| `--exclude-extra`          | Exclude extra dependencies (dev, optional, etc)           | `false`           |
 | `--direct-only`            | Check only direct dependencies                            | `false`           |
 | `--detailed`               | Show full vulnerability descriptions instead of truncated | `false`           |
 | `--ignore`                 | Vulnerability IDs to ignore (repeatable)                  | `[]`              |

--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ pysentry --format markdown --output security-report.md
 # Ignore specific vulnerabilities
 pysentry --ignore CVE-2023-12345 --ignore GHSA-xxxx-yyyy-zzzz
 
+# Ignore unfixable vulnerabilities (only while they have no fix available)
+pysentry --ignore-while-no-fix CVE-2025-8869
+
 # Disable caching for CI environments
 pysentry --no-cache
 
@@ -333,6 +336,7 @@ color = "auto"
 
 [ignore]
 ids = ["CVE-2023-12345", "GHSA-xxxx-yyyy-zzzz"]
+while_no_fix = ["CVE-2025-8869"]
 ```
 
 ### Environment Variables
@@ -354,6 +358,7 @@ ids = ["CVE-2023-12345", "GHSA-xxxx-yyyy-zzzz"]
 | `--direct-only`            | Check only direct dependencies                            | `false`           |
 | `--detailed`               | Show full vulnerability descriptions instead of truncated | `false`           |
 | `--ignore`                 | Vulnerability IDs to ignore (repeatable)                  | `[]`              |
+| `--ignore-while-no-fix`    | Ignore vulnerabilities only while no fix is available     | `[]`              |
 | `--output`                 | Output file path                                          | `stdout`          |
 | `--no-cache`               | Disable all caching                                       | `false`           |
 | `--cache-dir`              | Custom cache directory                                    | Platform-specific |

--- a/README.md
+++ b/README.md
@@ -337,7 +337,16 @@ color = "auto"
 [ignore]
 ids = ["CVE-2023-12345", "GHSA-xxxx-yyyy-zzzz"]
 while_no_fix = ["CVE-2025-8869"]
+
+[http]
+timeout = 120
+connect_timeout = 30
+max_retries = 3
+retry_initial_backoff = 1
+retry_max_backoff = 60
+show_progress = true
 ```
+
 
 ### Environment Variables
 
@@ -727,6 +736,42 @@ curl -I https://osv-vulnerabilities.storage.googleapis.com/
 # Try with different or multiple sources
 pysentry --sources pypi
 pysentry --sources pypa,osv
+
+# For slow or unstable networks, increase timeout and retries
+# Create/edit .pysentry.toml in your project:
+```
+
+```toml
+[http]
+timeout = 300           # 5 minute timeout
+max_retries = 5         # More retry attempts
+retry_max_backoff = 120 # Longer backoff delays
+```
+
+```bash
+# Then run again
+pysentry
+```
+
+**Network timeout errors:**
+
+PySentry includes automatic retry with exponential backoff for network issues. If you still experience timeouts:
+
+```bash
+# Increase timeout values in config
+pysentry config init --output .pysentry.toml
+# Edit .pysentry.toml and adjust [http] section
+```
+
+**Rate limiting (HTTP 429 errors):**
+
+PySentry automatically handles rate limiting. If rate limits persist:
+
+```toml
+[http]
+max_retries = 5              # More attempts
+retry_initial_backoff = 5    # Longer initial wait
+retry_max_backoff = 300      # Up to 5 minute backoff
 ```
 
 **Slow requirements.txt resolution**

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,6 +127,9 @@ pub struct IgnoreConfig {
     pub ids: Vec<String>,
 
     #[serde(default)]
+    pub while_no_fix: Vec<String>,
+
+    #[serde(default)]
     pub patterns: Vec<String>,
 
     #[serde(default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -551,7 +551,7 @@ fn default_fail_on() -> String {
     "medium".to_string()
 }
 fn default_scope() -> String {
-    "main".to_string()
+    "all".to_string()
 }
 fn default_sources() -> Vec<String> {
     vec!["pypa".to_string()]

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,13 @@ pub enum AuditError {
     #[error("Failed to download vulnerability database: {0}")]
     DatabaseDownload(Box<dyn std::error::Error + Send + Sync>),
 
+    #[error("Failed to download {resource} from {url}: {source}")]
+    DatabaseDownloadDetailed {
+        resource: String,
+        url: String,
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
     #[error("Failed to read project dependencies: {0}")]
     DependencyRead(Box<dyn std::error::Error + Send + Sync>),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,12 @@ impl AuditEngine {
             AuditCache::new(temp_dir)
         });
 
-        let vuln_source = VulnerabilitySource::new(source_type, cache, false);
+        let vuln_source = VulnerabilitySource::new(
+            source_type,
+            cache,
+            false,
+            crate::config::HttpConfig::default(),
+        );
 
         // 3. Fetch vulnerabilities
         let packages: Vec<(String, String)> = dependencies

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ impl AuditEngine {
         let matcher_config = MatcherConfig::new(
             min_severity,
             ignore_ids.to_vec(),
+            vec![],
             direct_only,
             include_withdrawn,
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,13 +32,15 @@ async fn main() -> Result<()> {
     match args.command {
         // No subcommand provided - run audit with flattened args
         None => {
-            let (merged_audit_args, _config) = match args.audit_args.load_and_merge_config() {
+            let (merged_audit_args, config) = match args.audit_args.load_and_merge_config() {
                 Ok(result) => result,
                 Err(e) => {
                     eprintln!("Configuration error: {e}");
                     std::process::exit(1);
                 }
             };
+
+            let http_config = config.as_ref().map(|c| c.http.clone()).unwrap_or_default();
 
             let log_level = if merged_audit_args.verbose {
                 "info"
@@ -56,7 +58,7 @@ async fn main() -> Result<()> {
                     .join("pysentry")
             });
 
-            let exit_code = audit(&merged_audit_args, &cache_dir).await?;
+            let exit_code = audit(&merged_audit_args, &cache_dir, http_config).await?;
 
             std::process::exit(exit_code);
         }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -28,6 +28,7 @@ pub(crate) use self::pypi::PypiSource;
 pub(crate) mod osv;
 mod pypa;
 mod pypi;
+mod retry;
 
 /// Trait for vulnerability data sources
 #[async_trait]
@@ -58,19 +59,17 @@ impl VulnerabilitySource {
         source: crate::types::VulnerabilitySource,
         cache: crate::AuditCache,
         no_cache: bool,
+        http_config: crate::config::HttpConfig,
     ) -> Self {
         match source {
             crate::types::VulnerabilitySource::Pypa => {
-                // PypaSource is now self-contained with direct PyPA parsing
-                VulnerabilitySource::PypaZip(PypaSource::new(cache, no_cache))
+                VulnerabilitySource::PypaZip(PypaSource::new(cache, no_cache, http_config))
             }
             crate::types::VulnerabilitySource::Pypi => {
-                // PypiSource queries PyPI JSON API directly
-                VulnerabilitySource::Pypi(PypiSource::new(cache, no_cache))
+                VulnerabilitySource::Pypi(PypiSource::new(cache, no_cache, http_config))
             }
             crate::types::VulnerabilitySource::Osv => {
-                // OsvSource directly queries OSV API
-                VulnerabilitySource::Osv(OsvSource::new(cache, no_cache))
+                VulnerabilitySource::Osv(OsvSource::new(cache, no_cache, http_config))
             }
         }
     }

--- a/src/providers/osv.rs
+++ b/src/providers/osv.rs
@@ -197,20 +197,19 @@ impl OsvSource {
 
     /// Convert OSV advisory to internal vulnerability format
     fn convert_osv_vulnerability(advisory: OsvAdvisory) -> Option<Vulnerability> {
-        // Extract package name from affected entries
         if advisory.affected.is_empty() {
             return None;
         }
-        let first_affected = &advisory.affected[0];
 
-        // Map OSV severity
         let severity = Self::map_osv_severity(&advisory);
 
-        // Extract version ranges
-        let affected_versions = Self::extract_osv_ranges(first_affected);
+        let mut affected_versions = Vec::new();
+        let mut fixed_versions = Vec::new();
 
-        // Extract fixed versions
-        let fixed_versions = Self::extract_fixed_versions(first_affected);
+        for affected in &advisory.affected {
+            affected_versions.extend(Self::extract_osv_ranges(affected));
+            fixed_versions.extend(Self::extract_fixed_versions(affected));
+        }
 
         // Build references
         let mut references = vec![];

--- a/src/providers/pypa.rs
+++ b/src/providers/pypa.rs
@@ -20,12 +20,14 @@ use crate::cache::CacheEntry;
 use crate::types::{PackageName, Version};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
 use tracing::debug;
 
+use super::retry::{is_http_error_retryable, retry_with_backoff};
 use crate::{
     AuditCache, AuditError, Result, Severity, VersionRange, Vulnerability, VulnerabilityDatabase,
     VulnerabilityProvider,
@@ -169,26 +171,46 @@ pub struct PypaSeverity {
 /// Client for downloading `PyPA` advisory database
 pub(super) struct PypaClient {
     client: Client,
+    http_config: crate::config::HttpConfig,
 }
 
 impl PypaClient {
-    /// Create a new `PyPA` client
-    pub(super) fn new() -> Self {
+    /// Create a new `PyPA` client with HTTP configuration
+    pub(super) fn new(http_config: crate::config::HttpConfig) -> Self {
         let client = Client::builder()
-            .user_agent(format!("uv/{}", env!("CARGO_PKG_VERSION")))
-            .timeout(std::time::Duration::from_secs(30))
+            .user_agent(format!("pysentry/{}", env!("CARGO_PKG_VERSION")))
+            .timeout(std::time::Duration::from_secs(http_config.timeout))
+            .connect_timeout(std::time::Duration::from_secs(http_config.connect_timeout))
             .build()
             .unwrap_or_else(|_| Client::new());
 
-        Self { client }
+        Self {
+            client,
+            http_config,
+        }
     }
 
-    /// Download the `PyPA` advisory database ZIP file
+    /// Download the `PyPA` advisory database ZIP file with retries and progress indication
     pub(super) async fn download_advisory_database(&self) -> Result<Vec<u8>> {
-        debug!(
-            "Downloading PyPA advisory database from {}",
-            PYPA_ADVISORY_DB_URL
-        );
+        retry_with_backoff(
+            self.http_config.max_retries,
+            self.http_config.retry_initial_backoff,
+            self.http_config.retry_max_backoff,
+            is_http_error_retryable,
+            || self.download_with_progress(),
+            "PyPA advisory database download",
+        )
+        .await
+        .map_err(|err| AuditError::DatabaseDownloadDetailed {
+            resource: "PyPA Advisory Database".to_string(),
+            url: PYPA_ADVISORY_DB_URL.to_string(),
+            source: Box::new(err),
+        })
+    }
+
+    /// Download the database with progress indication
+    async fn download_with_progress(&self) -> Result<Vec<u8>> {
+        use futures::StreamExt;
 
         let response = self.client.get(PYPA_ADVISORY_DB_URL).send().await?;
 
@@ -198,16 +220,53 @@ impl PypaClient {
             )));
         }
 
-        let bytes = response.bytes().await?;
-        debug!("Downloaded advisory database: {} bytes", bytes.len());
+        let total_size = response.content_length();
 
-        Ok(bytes.to_vec())
+        let pb = if self.http_config.show_progress {
+            if let Some(size) = total_size {
+                let bar = ProgressBar::new(size);
+                bar.set_style(
+                    ProgressStyle::default_bar()
+                        .template("{msg}\n{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+                        .unwrap()
+                        .progress_chars("#>-"),
+                );
+                bar.set_message("Downloading PyPA advisory database");
+                Some(bar)
+            } else {
+                let bar = ProgressBar::new_spinner();
+                bar.set_message("Downloading PyPA advisory database...");
+                Some(bar)
+            }
+        } else {
+            None
+        };
+
+        let mut downloaded: u64 = 0;
+        let mut stream = response.bytes_stream();
+        let mut bytes = Vec::new();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            bytes.extend_from_slice(&chunk);
+            downloaded += chunk.len() as u64;
+
+            if let Some(ref bar) = pb {
+                bar.set_position(downloaded);
+            }
+        }
+
+        if let Some(bar) = pb {
+            bar.finish_with_message("Downloaded PyPA advisory database");
+        }
+
+        Ok(bytes)
     }
 }
 
 impl Default for PypaClient {
     fn default() -> Self {
-        Self::new()
+        Self::new(crate::config::HttpConfig::default())
     }
 }
 
@@ -219,11 +278,11 @@ pub struct PypaSource {
 }
 
 impl PypaSource {
-    /// Create a new `PyPA` source
-    pub fn new(cache: AuditCache, no_cache: bool) -> Self {
+    /// Create a new `PyPA` source with HTTP configuration
+    pub fn new(cache: AuditCache, no_cache: bool, http_config: crate::config::HttpConfig) -> Self {
         Self {
             cache,
-            client: PypaClient::new(),
+            client: PypaClient::new(http_config),
             no_cache,
         }
     }
@@ -647,6 +706,10 @@ mod tests {
         AuditCache::new(temp_dir.path().to_path_buf())
     }
 
+    fn create_test_http_config() -> crate::config::HttpConfig {
+        crate::config::HttpConfig::default()
+    }
+
     #[test]
     fn test_pypa_advisory_parsing() {
         let yaml = r#"
@@ -678,7 +741,7 @@ modified: "2021-07-15T02:22:07.728618Z"
 published: "2007-10-30T19:46:00Z"
 "#;
 
-        let _source = PypaSource::new(create_test_cache(), true);
+        let _source = PypaSource::new(create_test_cache(), true, create_test_http_config());
 
         let advisory = PypaSource::parse_advisory(yaml).unwrap();
         assert_eq!(advisory.id, "PYSEC-2007-1");
@@ -706,7 +769,7 @@ affected:
 references: []
 ";
 
-        let _source = PypaSource::new(create_test_cache(), true);
+        let _source = PypaSource::new(create_test_cache(), true, create_test_http_config());
 
         let pypa_advisory = PypaSource::parse_advisory(yaml).unwrap();
         let package_names = PypaSource::extract_package_names(&pypa_advisory);
@@ -734,7 +797,7 @@ affected:
 references: []
 ";
 
-        let _source = PypaSource::new(create_test_cache(), true);
+        let _source = PypaSource::new(create_test_cache(), true, create_test_http_config());
 
         let pypa_advisory = PypaSource::parse_advisory(yaml).unwrap();
         let package_names = PypaSource::extract_package_names(&pypa_advisory);
@@ -769,7 +832,7 @@ affected:
 references: []
 ";
 
-        let _source = PypaSource::new(create_test_cache(), true);
+        let _source = PypaSource::new(create_test_cache(), true, create_test_http_config());
 
         let pypa_advisory = PypaSource::parse_advisory(yaml).unwrap();
         let package_names = PypaSource::extract_package_names(&pypa_advisory);
@@ -803,7 +866,7 @@ modified: \"2025-01-14T21:22:18.665005Z\"
 published: \"2025-01-14T19:15:32Z\"
 ";
 
-        let _source = PypaSource::new(create_test_cache(), true);
+        let _source = PypaSource::new(create_test_cache(), true, create_test_http_config());
 
         let pypa_advisory = PypaSource::parse_advisory(yaml).unwrap();
         let package_name = PackageName::from_str("requests").unwrap();
@@ -843,7 +906,7 @@ published: "2022-12-07T00:00:00Z"
 withdrawn: "2023-11-08T00:54:24Z"
 "#;
 
-        let _source = PypaSource::new(create_test_cache(), true);
+        let _source = PypaSource::new(create_test_cache(), true, create_test_http_config());
 
         let pypa_advisory = PypaSource::parse_advisory(yaml).unwrap();
         let package_name = PackageName::from_str("aiohttp").unwrap();

--- a/src/providers/pypa.rs
+++ b/src/providers/pypa.rs
@@ -406,7 +406,7 @@ impl PypaSource {
             cvss_score,
             published,
             modified,
-            source: Some("pypa-zip".to_string()),
+            source: Some("pypa".to_string()),
             withdrawn,
         })
     }
@@ -621,7 +621,7 @@ impl PypaSource {
 #[async_trait]
 impl VulnerabilityProvider for PypaSource {
     fn name(&self) -> &'static str {
-        "pypa-zip"
+        "pypa"
     }
 
     async fn fetch_vulnerabilities(
@@ -816,7 +816,7 @@ published: \"2025-01-14T19:15:32Z\"
             vulnerability.description,
             Some("Test vulnerability conversion".to_string())
         );
-        assert_eq!(vulnerability.source, Some("pypa-zip".to_string()));
+        assert_eq!(vulnerability.source, Some("pypa".to_string()));
         assert_eq!(vulnerability.references.len(), 1);
         assert_eq!(vulnerability.withdrawn, None);
     }

--- a/src/providers/retry.rs
+++ b/src/providers/retry.rs
@@ -1,0 +1,86 @@
+use crate::{AuditError, Result};
+use std::future::Future;
+use tokio::time::{sleep, Duration};
+use tracing::debug;
+
+/// Execute an async operation with exponential backoff retry logic
+///
+/// This is a generic retry mechanism that can wrap any async operation.
+/// It implements exponential backoff with configurable parameters.
+///
+/// # Arguments
+/// * `max_retries` - Maximum number of retry attempts (0 = no retries)
+/// * `initial_backoff` - Initial backoff duration in seconds
+/// * `max_backoff` - Maximum backoff duration in seconds (cap)
+/// * `is_retryable` - Function to determine if an error should trigger retry
+/// * `operation` - Async operation to execute (can be called multiple times)
+/// * `context` - Description of operation for logging
+///
+/// # Example
+/// ```ignore
+/// let result = retry_with_backoff(
+///     3,  // max retries
+///     1,  // 1s initial backoff
+///     60, // 60s max backoff
+///     |err| matches!(err, AuditError::Http(_)),
+///     || async { fetch_data().await },
+///     "fetch vulnerability data"
+/// ).await;
+/// ```
+pub async fn retry_with_backoff<F, Fut, T>(
+    max_retries: u32,
+    initial_backoff: u64,
+    max_backoff: u64,
+    is_retryable: impl Fn(&AuditError) -> bool,
+    mut operation: F,
+    context: &str,
+) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let mut attempt = 0;
+
+    loop {
+        attempt += 1;
+
+        match operation().await {
+            Ok(result) => return Ok(result),
+            Err(err) if attempt <= max_retries && is_retryable(&err) => {
+                let backoff_secs =
+                    std::cmp::min(initial_backoff * 2_u64.pow(attempt - 1), max_backoff);
+
+                debug!(
+                    "{} failed (attempt {}/{}): {}. Retrying in {}s...",
+                    context,
+                    attempt,
+                    max_retries + 1,
+                    err,
+                    backoff_secs
+                );
+
+                sleep(Duration::from_secs(backoff_secs)).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+/// Check if an error is retryable (transient network issues)
+///
+/// This is the standard retry policy for HTTP operations:
+/// - Timeouts (connection or read)
+/// - Connection errors
+/// - Rate limiting (429)
+/// - Service unavailable (503)
+pub fn is_http_error_retryable(err: &AuditError) -> bool {
+    match err {
+        AuditError::Http(e) => {
+            e.is_timeout()
+                || e.is_connect()
+                || e.status()
+                    .is_some_and(|s| s.as_u16() == 429 || s.as_u16() == 503)
+        }
+        _ => false,
+    }
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -73,7 +73,9 @@ fn run_cli(args: Vec<String>) -> PyResult<i32> {
                         .join("pysentry")
                 });
 
-                match audit(&audit_args, &cache_dir).await {
+                let http_config = crate::config::HttpConfig::default();
+
+                match audit(&audit_args, &cache_dir, http_config).await {
                     Ok(exit_code) => Ok(exit_code),
                     Err(e) => {
                         eprintln!("Error: Audit failed: {e}");

--- a/src/vulnerability/database.rs
+++ b/src/vulnerability/database.rs
@@ -55,7 +55,7 @@ pub struct Vulnerability {
     /// Date when vulnerability was last modified
     pub modified: Option<DateTime<Utc>>,
 
-    /// Source of the vulnerability data (e.g., "pypa-zip", "pypi", "osv")
+    /// Source of the vulnerability data (e.g., "pypa", "pypi", "osv")
     pub source: Option<String>,
 
     /// Date when vulnerability was withdrawn (if applicable)

--- a/src/vulnerability/matcher.rs
+++ b/src/vulnerability/matcher.rs
@@ -32,6 +32,8 @@ pub struct MatcherConfig {
     pub min_severity: SeverityLevel,
     /// Vulnerability IDs to ignore
     pub ignore_ids: HashSet<String>,
+    /// Vulnerability IDs to ignore only while no fix is available
+    pub ignore_while_no_fix: HashSet<String>,
     /// Only check direct dependencies
     pub direct_only: bool,
     /// Include withdrawn vulnerabilities
@@ -43,12 +45,14 @@ impl MatcherConfig {
     pub fn new(
         min_severity: SeverityLevel,
         ignore_ids: Vec<String>,
+        ignore_while_no_fix: Vec<String>,
         direct_only: bool,
         include_withdrawn: bool,
     ) -> Self {
         Self {
             min_severity,
             ignore_ids: ignore_ids.into_iter().collect(),
+            ignore_while_no_fix: ignore_while_no_fix.into_iter().collect(),
             direct_only,
             include_withdrawn,
         }
@@ -67,6 +71,15 @@ impl MatcherConfig {
     /// Check if a vulnerability ID should be ignored
     pub fn should_ignore(&self, vulnerability_id: &str) -> bool {
         self.ignore_ids.contains(vulnerability_id)
+    }
+
+    /// Check if a vulnerability ID should be ignored while it has no fix
+    pub fn should_ignore_while_no_fix(&self, vulnerability_id: &str, has_fix: bool) -> bool {
+        if has_fix {
+            false
+        } else {
+            self.ignore_while_no_fix.contains(vulnerability_id)
+        }
     }
 
     pub fn should_include_withdrawn(&self, vulnerability: &Vulnerability) -> bool {
@@ -147,6 +160,15 @@ impl VulnerabilityMatcher {
                 if let Some(vulnerability) = self.database.advisories.get(vuln_index) {
                     // Check if this vulnerability should be ignored
                     if self.config.should_ignore(&vulnerability.id) {
+                        continue;
+                    }
+
+                    // Check if this vulnerability should be ignored while no fix is available
+                    let has_fix = !vulnerability.fixed_versions.is_empty();
+                    if self
+                        .config
+                        .should_ignore_while_no_fix(&vulnerability.id, has_fix)
+                    {
                         continue;
                     }
 
@@ -444,6 +466,7 @@ mod tests {
         let config = MatcherConfig::new(
             SeverityLevel::High,
             vec!["IGNORE-001".to_string()],
+            vec![],
             true,
             false,
         );
@@ -460,7 +483,7 @@ mod tests {
     #[test]
     fn test_vulnerability_matching() {
         let database = create_test_database();
-        let config = MatcherConfig::new(SeverityLevel::Low, vec![], false, false);
+        let config = MatcherConfig::new(SeverityLevel::Low, vec![], vec![], false, false);
         let matcher = VulnerabilityMatcher::new(database, config);
 
         let dependencies = vec![
@@ -489,7 +512,7 @@ mod tests {
     #[test]
     fn test_version_range_matching() {
         let database = create_test_database();
-        let config = MatcherConfig::new(SeverityLevel::Low, vec![], false, false);
+        let config = MatcherConfig::new(SeverityLevel::Low, vec![], vec![], false, false);
         let matcher = VulnerabilityMatcher::new(database, config);
 
         let vulnerability = &matcher.database.advisories[0];
@@ -516,7 +539,7 @@ mod tests {
     #[test]
     fn test_fix_analysis() {
         let database = create_test_database();
-        let config = MatcherConfig::new(SeverityLevel::Low, vec![], false, false);
+        let config = MatcherConfig::new(SeverityLevel::Low, vec![], vec![], false, false);
         let matcher = VulnerabilityMatcher::new(database, config);
 
         let matches = vec![VulnerabilityMatch {
@@ -531,6 +554,95 @@ mod tests {
         assert_eq!(analysis.fixable, 1);
         assert_eq!(analysis.unfixable, 0);
         assert_eq!(analysis.fix_suggestions.len(), 1);
+    }
+
+    #[test]
+    fn test_ignore_when_no_fix() {
+        let mut vulnerability_with_fix = create_test_vulnerability();
+        vulnerability_with_fix.id = "CVE-2025-1234".to_string();
+        vulnerability_with_fix.fixed_versions = vec![Version::from_str("1.5.0").unwrap()];
+
+        let mut vulnerability_without_fix = create_test_vulnerability();
+        vulnerability_without_fix.id = "CVE-2025-5678".to_string();
+        vulnerability_without_fix.fixed_versions = vec![];
+
+        let mut package_index = HashMap::new();
+        package_index.insert(PackageName::from_str("test-package").unwrap(), vec![0, 1]);
+
+        let database = VulnerabilityDatabase {
+            advisories: vec![vulnerability_with_fix, vulnerability_without_fix],
+            package_index,
+        };
+
+        let config_ignore_unfixable = MatcherConfig::new(
+            SeverityLevel::Low,
+            vec![],
+            vec!["CVE-2025-5678".to_string()],
+            false,
+            false,
+        );
+        let matcher_ignore_unfixable =
+            VulnerabilityMatcher::new(database.clone(), config_ignore_unfixable);
+
+        let dependencies = vec![ScannedDependency {
+            name: PackageName::from_str("test-package").unwrap(),
+            version: Version::from_str("1.2.0").unwrap(),
+            is_direct: true,
+            source: DependencySource::Registry,
+            path: None,
+        }];
+
+        let matches = matcher_ignore_unfixable
+            .find_vulnerabilities(&dependencies)
+            .unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].vulnerability.id, "CVE-2025-1234");
+
+        let config_no_ignore = MatcherConfig::new(SeverityLevel::Low, vec![], vec![], false, false);
+        let matcher_no_ignore = VulnerabilityMatcher::new(database, config_no_ignore);
+        let matches_all = matcher_no_ignore
+            .find_vulnerabilities(&dependencies)
+            .unwrap();
+
+        assert_eq!(matches_all.len(), 2);
+    }
+
+    #[test]
+    fn test_ignore_when_no_fix_does_not_ignore_fixable() {
+        let mut vulnerability_with_fix = create_test_vulnerability();
+        vulnerability_with_fix.id = "CVE-2025-9999".to_string();
+        vulnerability_with_fix.fixed_versions = vec![Version::from_str("1.5.0").unwrap()];
+
+        let mut package_index = HashMap::new();
+        package_index.insert(PackageName::from_str("test-package").unwrap(), vec![0]);
+
+        let database = VulnerabilityDatabase {
+            advisories: vec![vulnerability_with_fix],
+            package_index,
+        };
+
+        let config = MatcherConfig::new(
+            SeverityLevel::Low,
+            vec![],
+            vec!["CVE-2025-9999".to_string()],
+            false,
+            false,
+        );
+        let matcher = VulnerabilityMatcher::new(database, config);
+
+        let dependencies = vec![ScannedDependency {
+            name: PackageName::from_str("test-package").unwrap(),
+            version: Version::from_str("1.2.0").unwrap(),
+            is_direct: true,
+            source: DependencySource::Registry,
+            path: None,
+        }];
+
+        let matches = matcher.find_vulnerabilities(&dependencies).unwrap();
+
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].vulnerability.id, "CVE-2025-9999");
     }
 
     #[test]
@@ -549,7 +661,7 @@ mod tests {
             package_index,
         };
 
-        let config_exclude = MatcherConfig::new(SeverityLevel::Low, vec![], false, false);
+        let config_exclude = MatcherConfig::new(SeverityLevel::Low, vec![], vec![], false, false);
         let matcher_exclude = VulnerabilityMatcher::new(database.clone(), config_exclude);
 
         let dependencies = vec![ScannedDependency {
@@ -563,7 +675,7 @@ mod tests {
         let matches_exclude = matcher_exclude.find_vulnerabilities(&dependencies).unwrap();
         assert_eq!(matches_exclude.len(), 0);
 
-        let config_include = MatcherConfig::new(SeverityLevel::Low, vec![], false, true);
+        let config_include = MatcherConfig::new(SeverityLevel::Low, vec![], vec![], false, true);
         let matcher_include = VulnerabilityMatcher::new(database, config_include);
 
         let matches_include = matcher_include.find_vulnerabilities(&dependencies).unwrap();

--- a/src/vulnerability/matcher.rs
+++ b/src/vulnerability/matcher.rs
@@ -281,8 +281,15 @@ impl VulnerabilityMatcher {
             if !m.vulnerability.fixed_versions.is_empty() {
                 analysis.fixable += 1;
 
-                // Find the best fix version (usually the minimum fixed version)
-                if let Some(fix_version) = m.vulnerability.fixed_versions.first() {
+                let fix_version = m
+                    .vulnerability
+                    .fixed_versions
+                    .iter()
+                    .filter(|v| *v > &m.installed_version)
+                    .min()
+                    .or_else(|| m.vulnerability.fixed_versions.first());
+
+                if let Some(fix_version) = fix_version {
                     analysis.fix_suggestions.push(FixSuggestion {
                         package_name: m.package_name.clone(),
                         current_version: m.installed_version.clone(),


### PR DESCRIPTION
## Breaking Changes:
- Optional dependencies now included by default. Use --exclude-extra to scan only main dependencies.

## New Features:
- HTTP retry configuration with exponential backoff
- `--ignore-while-no-fix` flag for vulnerability suppression
- Improved fix version recommendations

## Bug Fixes:
- Fixed version resolution for vulnerabilities with multiple affected ranges (#81)
- More accurate fix suggestions that only recommend upgrades

## Improvements:
- Clearer source naming ("pypa" instead of "pypa-zip")
- Better network reliability with configurable retries
