### PR TITLE
Fix Python CLI keyboard interrupt handling

### DIFF
--- a/python/pysentry/__init__.py
+++ b/python/pysentry/__init__.py
@@ -1,5 +1,8 @@
 """pysentry-rs: Security vulnerability auditing tool for Python packages."""
 
+import sys
+import threading
+
 from ._internal import get_version, run_cli
 
 __version__ = get_version()
@@ -8,16 +11,31 @@ __all__ = ["get_version", "run_cli", "main"]
 
 def main():
     """CLI entry point that provides the exact same interface as the Rust binary."""
-    import sys
+    result = [None]
+    exception = [None]
+
+    def worker():
+        try:
+            result[0] = run_cli(sys.argv)
+        except Exception as e:
+            exception[0] = e
+
+    # Run Rust code in daemon thread so main thread can handle signals
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
 
     try:
-        # Pass all arguments directly to the Rust CLI - this ensures perfect compatibility
-        exit_code = run_cli(sys.argv)
-        sys.exit(exit_code)
+        while thread.is_alive():
+            thread.join(timeout=0.1)  # Check for signals every 100ms
+    except KeyboardInterrupt:
+        print("\nInterrupted", file=sys.stderr)
+        sys.exit(130)  # 128 + SIGINT(2) - Unix convention
 
-    except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
+    if exception[0] is not None:
+        print(f"Error: {exception[0]}", file=sys.stderr)
         sys.exit(1)
+
+    sys.exit(result[0] if result[0] is not None else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements proper KeyboardInterrupt (Ctrl+C) handling for the Python CLI by running Rust code in a daemon thread and releasing the GIL during execution. This allows Python to handle signals while Rust is running, enabling clean termination with exit code 130.

Closes #79