### PR TITLE
v0.4.8 "CI-native"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
     id: version
     attributes:
       label: PySentry Version
-      placeholder: "e.g. 0.4.7 — run `pysentry-rs --version`"
+      placeholder: "e.g. 0.4.8 — run `pysentry-rs --version`"
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "pysentry"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pysentry"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 rust-version = "1.79"
 description = "Security vulnerability auditing for Python packages"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ More examples in the [quickstart guide](https://docs.pysentry.com/getting-starte
 ```yaml
 repos:
   - repo: https://github.com/pysentry/pysentry-pre-commit
-    rev: v0.4.7
+    rev: v0.4.8
     hooks:
       - id: pysentry
         # args: ['--compact']  # terser output for hook runs

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -4,6 +4,65 @@ sidebar_position: 5
 
 # Changelog
 
+## v0.4.8 "CI-native"
+
+### ✨ New Features
+
+#### First-Party GitHub Action
+
+PySentry ships an official GitHub Action. It downloads the prebuilt release binary for the runner platform, verifies it against the release `SHA256SUMS`, runs the audit, and uploads a SARIF report to GitHub Code Scanning — findings appear in the repository Security tab and on pull requests:
+
+```yaml
+permissions:
+  security-events: write
+
+steps:
+  - uses: actions/checkout@v4
+  - uses: nyudenkov/pysentry@v0.4.8
+    with:
+      fail-on: high
+```
+
+Inputs map 1:1 to CLI flags (`path`, `fail-on`, `sources`, `format`, `output`, `ignore`, plus a raw `args` passthrough). The SARIF report is uploaded even when the audit fails, so findings always reach the Security tab before the job exits non-zero. See the [CI guide](/ci) — it also covers other CI systems.
+
+#### `--service-url`: Custom OSV-Compatible Endpoint
+
+Corporate and air-gapped environments can point the OSV provider at a self-hosted or mirrored OSV-compatible endpoint:
+
+```bash
+pysentry-rs --sources osv --service-url https://osv.internal.example.com
+```
+
+Only valid with `--sources osv`; also available as a config file option.
+
+#### Distinct Exit Code for System Errors
+
+Exit code `1` previously meant both "vulnerabilities found" and "the audit never ran". System errors (bad configuration, network failure, parse failure) now exit `2`; findings at or above the `--fail-on` threshold keep `1`. CI can gate on any non-zero exit as before, or handle the two cases separately.
+
+### 🔧 Improvements
+
+#### SARIF Reports Carry Line Numbers for Every Source
+
+SARIF results previously included a source line only for `pyproject.toml` and `uv.lock`; every other project layout produced results GitHub Code Scanning could not anchor. Location scanning now covers everything the parsers read: `requirements.txt` (including multi-file audits), `poetry.lock`, `pylock.toml`, `Pipfile.lock`, `Pipfile`, and — inside `pyproject.toml` — extras and PEP 735 dependency groups.
+
+#### Maintenance Checks Skip Non-Registry Dependencies
+
+PEP 792 maintenance status checks no longer query PyPI for Git, path, and URL dependencies that cannot exist there — fewer wasted requests and no meaningless "not found" results.
+
+#### Own Supply Chain Hardening
+
+Release assets now ship with a `SHA256SUMS` file, verified by the GitHub Action before running the binary. The project's own `cargo audit` CI job is pinned and runs against a reviewed, commented ignore list, and `quinn-proto` was bumped to 0.11.15 (RUSTSEC-2026-0185).
+
+#### OSV and PyPI Clients Identify Themselves
+
+Both clients now send a `pysentry/{version}` user-agent, matching the rest of the codebase.
+
+### 🐛 Bug Fixes
+
+- **SARIF: multi-file requirements audits emitted a bogus URI.** Auditing several requirements files produced `artifactLocation.uri` values like `"requirements.txt, dev-requirements.txt"`; each finding now resolves to its own real file.
+- **SARIF: substring package matching.** Location scanning could anchor `jinja2` to a `flask-jinja2` line; names are now compared through full PEP 503 normalization.
+- **Advisory aliases were double-reported in single-source audits.** Aliased advisories (e.g. the same CVE under GHSA and PYSEC IDs) are collapsed into one finding.
+
 ## v0.4.7 "Hardening"
 
 ### ✨ New Features

--- a/docs/docs/getting-started/quickstart.md
+++ b/docs/docs/getting-started/quickstart.md
@@ -144,9 +144,10 @@ PySentry reports vulnerabilities with:
 | Code | Meaning |
 |------|---------|
 | 0 | No vulnerabilities found at or above the `--fail-on` threshold |
-| 1 | Vulnerabilities found at or above the `--fail-on` threshold, or error during execution |
+| 1 | Vulnerabilities found at or above the `--fail-on` threshold |
+| 2 | Error: the audit did not complete (bad configuration, network failure, parse failure) |
 
-Note: Both vulnerability detection and errors result in exit code 1. Use verbose output (`-v`) to distinguish between them.
+CI can rely on the distinction: `1` means "vulnerable", `2` means "the audit never ran" — gate on any non-zero, or handle them separately.
 
 ## Next Steps
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -335,7 +335,7 @@ pysentry-rs --format json --output results.json
 # Use faster resolver and limit sources
 repos:
   - repo: https://github.com/pysentry/pysentry-pre-commit
-    rev: v0.4.7
+    rev: v0.4.8
     hooks:
       - id: pysentry
         args: ["--resolver", "uv", "--sources", "pypa"]

--- a/src/audit/pipeline.rs
+++ b/src/audit/pipeline.rs
@@ -22,6 +22,12 @@ use futures::future::try_join_all;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
+/// Findings at/above the `fail_on` threshold (or failing maintenance issues)
+pub const EXIT_VULNERABILITIES_FOUND: i32 = 1;
+/// System errors (bad config, network failure, parse failure) — distinguishable
+/// from findings so CI can tell "vulnerable" from "audit never ran"
+pub const EXIT_ERROR: i32 = 2;
+
 #[cfg_attr(feature = "hotpath", hotpath::measure)]
 pub async fn audit(
     audit_args: &AuditArgs,
@@ -38,7 +44,7 @@ pub async fn audit(
         Ok(sources) => sources,
         Err(e) => {
             eprintln!("Error: Invalid vulnerability sources: {e}");
-            return Ok(1);
+            return Ok(EXIT_ERROR);
         }
     };
 
@@ -88,7 +94,7 @@ pub async fn audit(
         Ok(result) => result,
         Err(e) => {
             eprintln!("Error: Audit failed: {e}");
-            return Ok(1);
+            return Ok(EXIT_ERROR);
         }
     };
 
@@ -206,7 +212,7 @@ pub async fn audit(
     let fail_maintenance = report.should_fail_on_maintenance(&maintenance_config);
 
     if fail_vulns || fail_maintenance {
-        Ok(1)
+        Ok(EXIT_VULNERABILITIES_FOUND)
     } else {
         Ok(0)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,9 @@ async fn main() -> ExitCode {
         Ok(code) => ExitCode::from(code),
         Err(e) => {
             eprintln!("Error: {e}");
-            ExitCode::FAILURE
+            // invariant: EXIT_ERROR is 2, which fits u8
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            ExitCode::from(pysentry::audit::pipeline::EXIT_ERROR as u8)
         }
     }
 }
@@ -33,7 +35,9 @@ async fn run() -> Result<u8> {
                 Ok(result) => result,
                 Err(e) => {
                     eprintln!("Configuration error: {e}");
-                    return Ok(1);
+                    // invariant: EXIT_ERROR is 2, which fits u8
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    return Ok(pysentry::audit::pipeline::EXIT_ERROR as u8);
                 }
             };
 

--- a/src/providers/osv.rs
+++ b/src/providers/osv.rs
@@ -170,6 +170,7 @@ impl OsvSource {
         vulnerability_ttl: u64,
     ) -> Self {
         let client = reqwest::Client::builder()
+            .user_agent(format!("pysentry/{}", env!("CARGO_PKG_VERSION")))
             .timeout(std::time::Duration::from_secs(http_config.timeout))
             .connect_timeout(std::time::Duration::from_secs(http_config.connect_timeout))
             .build()

--- a/src/providers/pypi.rs
+++ b/src/providers/pypi.rs
@@ -39,6 +39,7 @@ impl PypiSource {
         vulnerability_ttl: u64,
     ) -> Self {
         let client = reqwest::Client::builder()
+            .user_agent(format!("pysentry/{}", env!("CARGO_PKG_VERSION")))
             .timeout(std::time::Duration::from_secs(http_config.timeout))
             .connect_timeout(std::time::Duration::from_secs(http_config.connect_timeout))
             .build()

--- a/src/python.rs
+++ b/src/python.rs
@@ -37,7 +37,7 @@ fn run_cli(py: Python<'_>, args: Vec<String>) -> PyResult<i32> {
             .map_err(|e| PyRuntimeError::new_err(format!("Failed to create async runtime: {e}")))?;
 
         rt.block_on(async {
-            use crate::audit::pipeline::audit;
+            use crate::audit::pipeline::{audit, EXIT_ERROR};
             use crate::cli::{Cli, Commands};
             use crate::commands::resolvers::check_resolvers;
             use clap::Parser;
@@ -59,7 +59,7 @@ fn run_cli(py: Python<'_>, args: Vec<String>) -> PyResult<i32> {
                         Ok(result) => result,
                         Err(e) => {
                             eprintln!("Configuration error: {e}");
-                            return Ok(1);
+                            return Ok(EXIT_ERROR);
                         }
                     };
 
@@ -98,7 +98,7 @@ fn run_cli(py: Python<'_>, args: Vec<String>) -> PyResult<i32> {
                         Ok(exit_code) => Ok(exit_code),
                         Err(e) => {
                             eprintln!("Error: Audit failed: {e}");
-                            Ok(1)
+                            Ok(EXIT_ERROR)
                         }
                     }
                 }
@@ -111,7 +111,7 @@ fn run_cli(py: Python<'_>, args: Vec<String>) -> PyResult<i32> {
                         Ok(()) => Ok(0),
                         Err(e) => {
                             eprintln!("Error: {e}");
-                            Ok(1)
+                            Ok(EXIT_ERROR)
                         }
                     }
                 }
@@ -124,7 +124,7 @@ fn run_cli(py: Python<'_>, args: Vec<String>) -> PyResult<i32> {
                         Ok(()) => Ok(0),
                         Err(e) => {
                             eprintln!("Error: {e}");
-                            Ok(1)
+                            Ok(EXIT_ERROR)
                         }
                     }
                 }
@@ -133,7 +133,7 @@ fn run_cli(py: Python<'_>, args: Vec<String>) -> PyResult<i32> {
                         Ok(()) => Ok(0),
                         Err(e) => {
                             eprintln!("Error: {e}");
-                            Ok(1)
+                            Ok(EXIT_ERROR)
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Release v0.4.8 "CI-native" — `dev` → `main`.

The release makes PySentry a first-class CI citizen. Closes #136, closes #120, closes #125.

- **First-party GitHub Action** (`action.yml`): downloads the prebuilt release binary, verifies it against `SHA256SUMS`, runs the audit, uploads SARIF to GitHub Code Scanning. Inputs map 1:1 to CLI flags.
- **CI guide** (`docs.pysentry.com/ci`) + README CI section — closes #120 by documentation, since `--fail-on` already provides the exit-code gate.
- **SARIF line numbers for every dependency source**: requirements.txt (incl. multi-file), poetry.lock, pylock.toml, Pipfile.lock, Pipfile, and pyproject extras / PEP 735 groups; fixes bogus multi-file URIs and substring package matching along the way.
- **`--service-url`** — custom OSV-compatible endpoint for corporate mirrors and air-gapped setups.
- **Exit code 2 for system errors** — CI can now tell "vulnerable" (1) from "audit never ran" (2).
- **Supply-chain hardening of our own CI**: pinned cargo-audit, reviewed advisory ignore list, `SHA256SUMS` on release assets, quinn-proto bump (RUSTSEC-2026-0185).
- Maintenance checks skip non-registry deps; OSV/PyPI clients send a user-agent; aliased advisories deduplicated in single-source audits.

- Internal: benchmark methodology rework with a ruff+ty gate, optional hotpath profiling instrumentation, config-test deflaking.

Full notes: [changelog](https://docs.pysentry.com/changelog).

## Checklist

- [x] `just done` passes (`cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo test`).