### PR TITLE
ci: upload release assets to the draft by id, fix benchmark flag

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run benchmark suite
         run: |
           cd benchmarks
-          uv run python main.py --skip-build --output-dir /tmp/bench-results
+          uv run python main.py --output-dir /tmp/bench-results
 
       - name: Locate result JSON
         id: result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Run benchmark suite
         run: |
           cd benchmarks
-          uv run python main.py --skip-build
+          uv run python main.py
 
           ls -la results/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
@@ -127,7 +127,7 @@ jobs:
   upload-release-assets:
     name: Upload Release Assets
     runs-on: ubuntu-latest
-    needs: build-binaries
+    needs: [create-release, build-binaries]
     permissions:
       contents: write
     steps:
@@ -147,13 +147,22 @@ jobs:
           sha256sum *.tar.gz *.zip > SHA256SUMS
           cat SHA256SUMS
 
+      # Upload by release id, NOT by tag: drafts are not tag-associated, so a
+      # tag lookup creates a second, published release — which under immutable
+      # releases can never receive assets (422, broke v0.4.8). The draft stays
+      # mutable until update-release publishes it with everything attached.
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: binaries/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for file in binaries/*; do
+            name=$(basename "$file")
+            echo "Uploading $name"
+            gh api --method POST \
+              -H "Content-Type: application/octet-stream" \
+              "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-release.outputs.release_id }}/assets?name=$name" \
+              --input "$file" > /dev/null
+          done
 
   verify-all-builds:
     name: Verify All Builds Complete
@@ -338,13 +347,15 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [publish-crates, publish-pypi]
+    needs: [create-release, publish-crates, publish-pypi]
     if: success()
     steps:
+      # Publish the draft by id (see the upload job comment): assets are already
+      # attached, so the release becomes immutable in its complete state
       - name: Mark release as published
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ github.ref_name }}
-          draft: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method PATCH \
+            "repos/${{ github.repository }}/releases/${{ needs.create-release.outputs.release_id }}" \
+            -F draft=false


### PR DESCRIPTION
<!--
Thanks for contributing to PySentry!
-->

## Summary

<!-- What does this PR change, and why? -->
The v0.4.8 release shipped empty: asset upload targeted the release by tag, but drafts are not tag-associated, so softprops@v1 created a second, already-published release — and with immutable releases enabled a published release can never receive assets (422). Every prior version left the same orphaned draft; mutability just masked it.
- upload assets to the draft via its release_id (stays mutable), publish it as the final step with everything attached
- softprops/action-gh-release v1 -> v2 in create-release
- drop the removed --skip-build flag from benchmark workflows (benchmarks auto-detect target/release/pysentry since the rework)

## Checklist

- [x] `just done` passes (`cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo test`).
