### PR TITLE
v0.4.9 "CI-native"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,7 +48,7 @@ body:
     id: version
     attributes:
       label: PySentry Version
-      placeholder: "e.g. 0.4.8 — run `pysentry-rs --version`"
+      placeholder: "e.g. 0.4.9 — run `pysentry-rs --version`"
     validations:
       required: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "pysentry"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pysentry"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 rust-version = "1.79"
 description = "Security vulnerability auditing for Python packages"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ More examples in the [quickstart guide](https://docs.pysentry.com/getting-starte
 ```yaml
 repos:
   - repo: https://github.com/pysentry/pysentry-pre-commit
-    rev: v0.4.8
+    rev: v0.4.9
     hooks:
       - id: pysentry
         # args: ['--compact']  # terser output for hook runs
@@ -92,7 +92,7 @@ permissions:
 
 steps:
   - uses: actions/checkout@v4
-  - uses: nyudenkov/pysentry@v0.4.8
+  - uses: nyudenkov/pysentry@v0.4.9
     with:
       fail-on: high
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: '.'
   version:
-    description: 'PySentry version to use (e.g. v0.4.8). Defaults to the version matching the action tag, or latest.'
+    description: 'PySentry version to use (e.g. v0.4.9). Defaults to the version matching the action tag, or latest.'
     required: false
     default: ''
   fail-on:

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Changelog
 
-## v0.4.8 "CI-native"
+## v0.4.9 "CI-native"
 
 ### ✨ New Features
 
@@ -18,7 +18,7 @@ permissions:
 
 steps:
   - uses: actions/checkout@v4
-  - uses: nyudenkov/pysentry@v0.4.8
+  - uses: nyudenkov/pysentry@v0.4.9
     with:
       fail-on: high
 ```

--- a/docs/docs/ci.md
+++ b/docs/docs/ci.md
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: nyudenkov/pysentry@v0.4.8
+      - uses: nyudenkov/pysentry@v0.4.9
         with:
           fail-on: high
 ```

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -335,7 +335,7 @@ pysentry-rs --format json --output results.json
 # Use faster resolver and limit sources
 repos:
   - repo: https://github.com/pysentry/pysentry-pre-commit
-    rev: v0.4.8
+    rev: v0.4.9
     hooks:
       - id: pysentry
         args: ["--resolver", "uv", "--sources", "pypa"]

--- a/examples/github-action.yml
+++ b/examples/github-action.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: PySentry audit
-        uses: nyudenkov/pysentry@v0.4.8
+        uses: nyudenkov/pysentry@v0.4.9
         with:
           # All inputs are optional; these are the common ones:
           fail-on: high            # fail the job on high/critical findings


### PR DESCRIPTION
<!--
Thanks for contributing to PySentry!
-->

## Summary

<!-- What does this PR change, and why? -->
Re-release of the failed v0.4.8: the empty immutable release burned the tag name, so the same content ships as v0.4.9. All version references bumped; no code changes on top of v0.4.8.

## Checklist

- [x] `just done` passes (`cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings` + `cargo test`).
